### PR TITLE
[fix] Arregla configuración de sonarcloud para medir cobertura de tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - mv application.properties_heroku application.properties
   - cd -
 script:
-  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=antnolang_EcoRenter
+  - mvn clean verify sonar:sonar -Pcoverage -Dsonar.projectKey=antnolang_EcoRenter
 before_deploy:
   if ! [ "$IS_TAGGED" ]; then
     export IS_TAGGED=1;

--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,48 @@
 
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+	<profiles>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>0.8.4</version>
+						<executions>
+							<execution>
+								<id>prepare-agent</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>report</id>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		<profile>
+			<id>default</id>
+			<activation>
+	            <activeByDefault>true</activeByDefault>
+	        </activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>


### PR DESCRIPTION
Faltaba añadir un perfil en el pom para que JaCoCo generase el report en formato XML